### PR TITLE
Fix constructing RegExp TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var utils = require('loader-utils');
 
 function processQuery(source, query) {
   if (!_.isUndefined(query.search) && !_.isUndefined(query.replace)) {
-    if (!_.isUndefined(query.flags)) {
+    if (!_.isUndefined(query.flags) && !_.isRegExp(query.search)) {
       query.search = new RegExp(query.search, query.flags);
     }
 


### PR DESCRIPTION
When dealing with multiple files and setting RegExp option, cause TypeError.

```js
// webpack.config.js
module: {
	rules: [
                {
                    test: /\.js$/,
                    loader: "string-replace-loader",
                    options: {
                        multiple: [
				{ search: "foo", replace: "bar", flags: "g" },
			]
		}
	]
}
```
subquery param value is passed to `processQuery()` as below
- first call: { search: 'foo', replace: 'bar', flags: 'g' }
- next calls: { search: /foo/g, replace: 'bar', flags: 'g' }

Causing `Module build failed: TypeError: Cannot supply flags when constructing one RegExp from another` error.

This PR fix that issue