### PR TITLE
Updated loader configuration read for webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var utils = require('loader-utils');
+var loaderUtils = require('loader-utils');
 
 function processQuery(source, query) {
   if (!_.isUndefined(query.search) && !_.isUndefined(query.replace)) {
@@ -14,9 +14,9 @@ function processQuery(source, query) {
 }
 
 module.exports = function (source) {
-  this.cacheable();
+  if(this.cacheable) this.cacheable();
 
-  var query = utils.parseQuery(this.query);
+  var query = loaderUtils.getOptions(this) || {};
 
   if (_.isArray(query.multiple)) {
     query.multiple.forEach(function (subquery) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "loader-utils": "^0.2.11",
+    "loader-utils": "^1.0.4",
     "lodash": "^3.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi! This is a small fix, that changed deprecated parseQuery() to getOptions() for webpack 2.
Will be great, if you can publish a fresh release. Thanks!