### PR TITLE
Pass through sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function processQuery(source, query) {
 
 module.exports = function (source, map) {
   this.cacheable();
+  this.async()
 
   var query = utils.parseQuery(this.query);
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function processQuery(source, query) {
   return source;
 }
 
-module.exports = function (source) {
+module.exports = function (source, map) {
   this.cacheable();
 
   var query = utils.parseQuery(this.query);
@@ -26,5 +26,5 @@ module.exports = function (source) {
     source = processQuery(source, query);
   }
 
-  return source;
+  this.callback(source, map);
 };


### PR DESCRIPTION
This will pass down the source maps to other loaders. It will produce a slightly less accurate SourceMap because source is changed but map hasn't. It's possible to fix that but it requires more work which I don't have time to fix it.

For anyone who's interested in using this fork: 

You can install it via:

```
npm i -D 'mohsen1/string-replace-loader#sourcemap'
```

Fixes #18 #23 