### PR TITLE
support source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function processOptions(source, options) {
   return newSource;
 }
 
-module.exports = function (source) {
+module.exports = function (source, map) {
   this.cacheable();
 
   var options = loaderUtils.getOptions(this);
@@ -32,5 +32,5 @@ module.exports = function (source) {
     source = processOptions(source, options);
   }
 
-  return source;
+  this.callback(null, source, map);
 };


### PR DESCRIPTION
This should fix #18.

I basically have the same setup as https://github.com/Va1/string-replace-loader/issues/18#issuecomment-304191356. With my fix source maps seem to work again.

The change basically shows the second example in the [old docs _"Identity loader with SourceMap support"_](https://webpack.github.io/docs/how-to-write-a-loader.html#examples).

Tested with webpack 2.6.1.