### PR TITLE
Mark as compatible with Webpack 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "mocha": "^2.3.2",
-    "webpack": "1 || 2"
+    "webpack": "1 || 2 || 3"
   },
   "peerDependencies": {
-    "webpack": "1 || 2"
+    "webpack": "1 || 2 || 3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Mark the package as compatible with Webpack 3.

npm refuses to install if using webpack 3, even everything seems to work fine