### PR TITLE
Replacement callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,33 @@ module.exports = {
 }
 ```
 
+### Replacement with callback
+
+You can specify a callback function to have dynamic replacement values.
+
+In your `webpack.config.js`:
+
+```javascript
+module.exports = {
+  // ...
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'string-replace-loader',
+        options: {
+          search: '^Hello, (.*)!$',
+          replace: function(match, p1, offset, string){
+            return 'Bonjour, ' + p1.toUpperCase() + '!!!';
+          },
+          flags: 'gi'
+        }
+      }
+    ]
+  }
+}
+``` 
+
 ### Strict mode replacement:
 
 You can enable strict mode to ensure that the replacement was performed.

--- a/lib/getOptionsArray.js
+++ b/lib/getOptionsArray.js
@@ -10,7 +10,10 @@ const optionsSchema = {
       type: 'string'
     },
     replace: {
-      type: 'string'
+      'anyOf': [
+        { 'typeof': 'function' },
+        { 'type': 'string' }
+      ]
     },
     flags: {
       type: 'string',


### PR DESCRIPTION
https://github.com/Va1/string-replace-loader/issues/40

I realised that [String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) already has the capability of using callbacks, so only the option validation had to be modified.

I would normally add a test, but I couldn't set up testing. It needs a certain `test/build/build.js` file that I have no idea how to generate.