### PR TITLE
provide loader context in replace function

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ module.exports = {
 }
 ``` 
 
+```javascript
+module.exports = {
+  // ...
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'string-replace-loader',
+        options: {
+          search: '^Hello, (.*)!$',
+          replace(match, p1, offset, string) {
+            console.log(this); // 'this' equal to loader context
+            return `Bonjour, ${p1.toUpperCase()}!`;
+          },
+          flags: 'g'
+        }
+      }
+    ]
+  }
+}
+``` 
+
 ### Strict mode replacement:
 
 You can enable strict mode to ensure that the replacement was performed.

--- a/lib/processChunk.js
+++ b/lib/processChunk.js
@@ -8,7 +8,7 @@ function processChunk (source, map) {
   let newSource = source
 
   for (const options of optionsArray) {
-    newSource = replace(newSource, options)
+    newSource = replace(newSource, options, this)
   }
 
   this.callback(null, newSource, map)

--- a/lib/replace.js
+++ b/lib/replace.js
@@ -1,5 +1,5 @@
 
-function replace (source, options) {
+function replace (source, options, context) {
   const { replace, flags, strict } = options
   const search = (
     flags === null
@@ -11,7 +11,7 @@ function replace (source, options) {
     throw new Error('Replace failed (strict mode) : options.search and options.replace are required')
   }
 
-  const newSource = source.replace(search, replace)
+  const newSource = source.replace(search, typeof replace === 'string' ? replace : replace.bind(context))
 
   if (strict && (newSource === source)) {
     throw new Error('Replace failed (strict mode) : ' + options.search + ' → ' + options.replace)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chars-replace-loader",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Replace loader for Webpack",
   "keywords": [
     "webpack",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "string-replace-loader",
+  "name": "chars-replace-loader",
   "version": "2.3.0",
   "description": "Replace loader for Webpack",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "string-replace-loader",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Replace loader for Webpack",
   "keywords": [
     "webpack",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Va1/string-replace-loader.git"
+    "url": "https://github.com/ikun/string-replace-loader"
   },
   "homepage": "https://github.com/Va1/string-replace-loader",
   "author": "Valentyn Barmashyn <barmashyn.val@gmail.com>",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -317,4 +317,30 @@ describe('Webpack replace loader ...', () => {
       }
     )
   })
+
+  it('should get context when replace is a function', done => {
+    webpack(getTestWebPackConfig(
+      {
+        test: /\.js$/,
+        loader: '__this-loader',
+        options: {
+          search: 'var value',
+          replace() {
+            return `var a /* ${Object.prototype.toString.call(this.callback)} */`
+          }
+        }
+      }),
+      (error, stats) => {
+        expect(error).to.equal(null)
+
+        fs.readFile(outputFilePath, 'utf8', (error, contents) => {
+          expect(error).to.equal(null)
+          expect(contents).to.be.a('string')
+          expect(contents).to.not.include('var value')
+          expect(contents).to.include('var a /* [object Function] */')
+          done()
+        })
+      }
+    )
+  })
 })


### PR DESCRIPTION
Sometimes we need to get some parameters in the replace function, such as 'this.resourcePath'.