### PR TITLE
Improve documentation - Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ module.exports = {
         test: /fileInWhichJQueryIsUndefined\.js$/,
         loader: 'string-replace-loader',
         options: {
-          search: /\$/i,
+          search: /\\$/i,
           replace: 'window.jQuery'
         }
       }
@@ -81,7 +81,7 @@ module.exports = {
         test: /fileInWhichJQueryIsUndefined\.js$/,
         loader: 'string-replace-loader',
         options: {
-          search: '\$',
+          search: '\\$',
           replace: 'window.jQuery',
           flags: 'i'
         }


### PR DESCRIPTION
Regex documentation is a bit confusing, and as there are no internet resources after manually debugging I noticed that \$ in something like '\$APPID\$' would just return the plain string of '$APPID$' and pass it to regex, which won't make differences if you put that value plainly. so instead of escaping our special regex character, we should do it by placing an escaped back-slash character '\\' so it still sends the backslash '\' to the Regex.